### PR TITLE
feat: add nutrient mixes feature and enhance dashboard components

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { ROUTE_JOURNAL } from "@/lib/routes";
+
+export default function CalendarRedirectPage() {
+  const router = useRouter();
+  useEffect(() => {
+    router.replace(ROUTE_JOURNAL);
+  }, [router]);
+  return null;
+}

--- a/app/nutrients/page.tsx
+++ b/app/nutrients/page.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Layout } from "@/components/layout";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useTranslation } from "@/hooks/use-translation";
+import { useAuthUser } from "@/hooks/use-auth-user";
+import { ROUTE_LOGIN } from "@/lib/routes";
+import { db } from "@/lib/firebase";
+import {
+  buildNutrientMixesPath,
+  buildNutrientMixPath,
+} from "@/lib/firebase-config";
+import {
+  addDoc,
+  collection,
+  deleteDoc,
+  doc,
+  getDocs,
+  orderBy,
+  query,
+  updateDoc,
+} from "firebase/firestore";
+import { Loader2, Plus, X } from "lucide-react";
+
+interface NutrientMix {
+  id: string;
+  name: string;
+  npk?: string;
+  notes?: string;
+  createdAt: string;
+}
+
+export default function NutrientsPage() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuthUser();
+  const userId = user?.uid ?? null;
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [mixes, setMixes] = useState<NutrientMix[]>([]);
+  const [search, setSearch] = useState("");
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<NutrientMix | null>(null);
+  const [name, setName] = useState("");
+  const [npk, setNpk] = useState("");
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user) router.push(ROUTE_LOGIN);
+  }, [authLoading, user, router]);
+
+  const fetchMixes = async () => {
+    if (!userId) return;
+    try {
+      const q = query(
+        collection(db, buildNutrientMixesPath(userId)),
+        orderBy("createdAt", "desc")
+      );
+      const snap = await getDocs(q);
+      const list: NutrientMix[] = [];
+      snap.forEach((d) => list.push({ id: d.id, ...(d.data() as any) }));
+      setMixes(list);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (userId) void fetchMixes();
+  }, [userId]);
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return mixes;
+    const q = search.toLowerCase();
+    return mixes.filter((m) => m.name.toLowerCase().includes(q));
+  }, [mixes, search]);
+
+  const resetForm = () => {
+    setEditing(null);
+    setName("");
+    setNpk("");
+    setNotes("");
+  };
+
+  const onOpenChange = (v: boolean) => {
+    setOpen(v);
+    if (!v) resetForm();
+  };
+
+  const handleSave = async () => {
+    if (!userId || !name.trim()) return;
+    setSaving(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        npk: npk.trim() || undefined,
+        notes: notes.trim() || undefined,
+        createdAt: new Date().toISOString(),
+      };
+      if (editing) {
+        await updateDoc(doc(db, buildNutrientMixPath(userId, editing.id)), {
+          ...payload,
+        });
+      } else {
+        await addDoc(collection(db, buildNutrientMixesPath(userId)), payload);
+      }
+      setOpen(false);
+      resetForm();
+      await fetchMixes();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleEdit = (mix: NutrientMix) => {
+    setEditing(mix);
+    setName(mix.name || "");
+    setNpk(mix.npk || "");
+    setNotes(mix.notes || "");
+    setOpen(true);
+  };
+
+  const handleDelete = async (mix: NutrientMix) => {
+    if (!userId) return;
+    await deleteDoc(doc(db, buildNutrientMixPath(userId, mix.id)));
+    await fetchMixes();
+  };
+
+  if (isLoading) {
+    return (
+      <Layout>
+        <div className="flex justify-center items-center h-64">
+          <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout>
+      <div className="mb-6 flex items-center justify-between gap-3">
+        <div>
+          <h1 className="text-3xl font-bold">{t("nutrients.title")}</h1>
+          <p className="text-muted-foreground">{t("nutrients.description")}</p>
+        </div>
+        <Dialog open={open} onOpenChange={onOpenChange}>
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className="h-4 w-4 mr-2" /> Agregar mezcla
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-lg">
+            <DialogHeader>
+              <DialogTitle>
+                {editing ? "Editar mezcla" : "Nueva mezcla"}
+              </DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="mix-name">Nombre</Label>
+                <Input
+                  id="mix-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="mix-npk">NPK</Label>
+                <Input
+                  id="mix-npk"
+                  placeholder="ej. 3-1-2"
+                  value={npk}
+                  onChange={(e) => setNpk(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="mix-notes">Notas</Label>
+                <Textarea
+                  id="mix-notes"
+                  rows={3}
+                  value={notes}
+                  onChange={(e) => setNotes(e.target.value)}
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => setOpen(false)}>
+                  <X className="h-4 w-4 mr-1" /> {t("common.cancel")}
+                </Button>
+                <Button onClick={handleSave} disabled={!name.trim() || saving}>
+                  {saving ? (
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                  ) : null}
+                  {editing ? t("common.save") : t("common.add")}
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="mb-4">
+        <Input
+          placeholder={t("search.placeholder")}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+      </div>
+
+      {filtered.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("nutrients.empty")}</CardTitle>
+            <CardDescription>{t("nutrients.emptyDesc")}</CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {filtered.map((mix) => (
+            <Card key={mix.id} className="group">
+              <CardHeader>
+                <CardTitle className="flex items-center justify-between">
+                  <span>{mix.name}</span>
+                  <div className="space-x-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => handleEdit(mix)}
+                    >
+                      {t("common.edit")}
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      onClick={() => handleDelete(mix)}
+                    >
+                      {t("common.delete")}
+                    </Button>
+                  </div>
+                </CardTitle>
+                {mix.npk ? (
+                  <CardDescription>NPK: {mix.npk}</CardDescription>
+                ) : null}
+              </CardHeader>
+              {mix.notes ? (
+                <CardContent className="text-sm text-muted-foreground">
+                  {mix.notes}
+                </CardContent>
+              ) : null}
+            </Card>
+          ))}
+        </div>
+      )}
+    </Layout>
+  );
+}

--- a/app/plants/[id]/page.tsx
+++ b/app/plants/[id]/page.tsx
@@ -34,6 +34,7 @@ import { Layout } from "@/components/layout";
 import { PlantDetails } from "@/components/plant/plant-details";
 import { JournalEntries } from "@/components/journal/journal-entries";
 import { AddLogForm } from "@/components/journal/add-log-form";
+import { EnvironmentChart } from "@/components/plant/environment-chart";
 import { ImageUpload } from "@/components/common/image-upload";
 import { DEFAULT_MAX_IMAGES, DEFAULT_MAX_SIZE_MB } from "@/lib/image-config";
 import { Loader2, Trash2, Plus, Star } from "lucide-react";
@@ -534,6 +535,17 @@ export default function PlantPage({
               setPlant((prev) => (prev ? { ...prev, ...patch } : prev))
             }
           />
+          <Card>
+            <CardHeader>
+              <CardTitle>{t("plantPage.environmentData")}</CardTitle>
+              <CardDescription>
+                {t("plantPage.environmentDataDesc")}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <EnvironmentChart data={environmentData} />
+            </CardContent>
+          </Card>
         </div>
       </div>
 

--- a/components/layout/index.tsx
+++ b/components/layout/index.tsx
@@ -20,6 +20,8 @@ import {
   Bell,
   Plus,
   Package,
+  Leaf,
+  FlaskConical,
 } from "lucide-react";
 import { useUserRoles } from "@/hooks/use-user-roles";
 import { usePremium } from "@/hooks/use-premium";
@@ -38,6 +40,7 @@ import {
   ROUTE_REMINDERS,
   ROUTE_SETTINGS,
   ROUTE_STASH,
+  ROUTE_NUTRIENTS,
   resolveHomePathForRoles,
 } from "@/lib/routes";
 import { CookieConsent } from "@/components/common/cookie-consent";
@@ -91,6 +94,11 @@ export function Layout({ children }: LayoutProps) {
       icon: Home,
     },
     {
+      href: ROUTE_PLANTS,
+      label: t("dashboard.yourPlants"),
+      icon: Leaf,
+    },
+    {
       href: ROUTE_PLANTS_NEW,
       label: t("nav.addPlant"),
       icon: Plus,
@@ -104,6 +112,11 @@ export function Layout({ children }: LayoutProps) {
       href: ROUTE_STASH,
       label: t("stash.title"),
       icon: Package,
+    },
+    {
+      href: ROUTE_NUTRIENTS,
+      label: "Nutrientes",
+      icon: FlaskConical,
     },
     {
       href: ROUTE_JOURNAL,

--- a/components/navigation/mobile-bottom-nav.tsx
+++ b/components/navigation/mobile-bottom-nav.tsx
@@ -5,7 +5,15 @@ import type React from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
-import { Home, Calendar, Plus, Settings, Package, Brain } from "lucide-react";
+import {
+  Home,
+  Calendar,
+  Plus,
+  Settings,
+  Package,
+  Brain,
+  FlaskConical,
+} from "lucide-react";
 import { useUserRoles } from "@/hooks/use-user-roles";
 import { cn } from "@/lib/utils";
 import {
@@ -24,6 +32,7 @@ import {
   ROUTE_SETTINGS,
   ROUTE_AI_CONSUMER,
   ROUTE_STASH,
+  ROUTE_NUTRIENTS,
 } from "@/lib/routes";
 
 export function MobileBottomNav(): React.ReactElement {
@@ -156,19 +165,19 @@ export function MobileBottomNav(): React.ReactElement {
               )}
             </div>
 
-            {/* Slot 4: grower = Reminders, consumer-only = AI Chat when premium */}
+            {/* Slot 4: grower = Nutrients, consumer-only = AI Chat when premium */}
             {roles.grower ? (
               <Link
-                href={ROUTE_STASH}
+                href={ROUTE_NUTRIENTS}
                 className={cn(
                   "flex h-12 flex-col items-center justify-center gap-1 rounded-md text-xs",
-                  isActive(ROUTE_STASH)
+                  isActive(ROUTE_NUTRIENTS)
                     ? "text-primary"
                     : "text-muted-foreground hover:text-foreground"
                 )}
-                aria-label="Stash"
+                aria-label="Nutrients"
               >
-                <Package className="h-5 w-5" />
+                <FlaskConical className="h-5 w-5" />
               </Link>
             ) : roles.consumer ? (
               <Link

--- a/components/plant/plant-card.tsx
+++ b/components/plant/plant-card.tsx
@@ -15,6 +15,7 @@ interface PlantCardProps {
   lastWatering?: LogEntry;
   lastFeeding?: LogEntry;
   lastTraining?: LogEntry;
+  compact?: boolean;
 }
 
 export function PlantCard({
@@ -22,6 +23,7 @@ export function PlantCard({
   lastWatering,
   lastFeeding,
   lastTraining,
+  compact = false,
 }: PlantCardProps) {
   const { t, language } = useTranslation();
   const router = useRouter();
@@ -74,60 +76,64 @@ export function PlantCard({
           </Badge>
         </div>
       </div>
-      <CardContent className="pb-2">
-        <div className="flex items-center text-sm text-muted-foreground">
-          <Badge variant="outline" className="mr-2">
-            {plant.growType === "indoor"
-              ? t("newPlant.indoor")
-              : t("newPlant.outdoor")}
-          </Badge>
-          {plant.growType === "indoor" && plant.lightSchedule && (
-            <Badge variant="outline">{plant.lightSchedule}</Badge>
-          )}
-        </div>
-      </CardContent>
-      <CardFooter className="pt-0 text-xs text-muted-foreground">
-        <div className="space-y-1">
-          <div className="flex items-center">
-            <Calendar className="h-3 w-3 mr-1" />
-            {plant.plantingDate &&
-              formatDateWithLocale(plant.plantingDate, "PPP", language)}
-          </div>
-          <div className="flex items-center">
-            <Droplet className="h-3 w-3 mr-1" />
-            {lastWatering ? (
-              <span>
-                {t("plantCard.lastWatering")}: {lastWatering.amount}ml (
-                {t(`watering.${lastWatering.method}`)})
-              </span>
-            ) : (
-              <span>{t("plantCard.noWateringRecords")}</span>
-            )}
-          </div>
-          <div className="flex items-center">
-            <Zap className="h-3 w-3 mr-1" />
-            {lastFeeding ? (
-              <span>
-                {t("plantCard.lastFeeding")}: {lastFeeding.npk} (
-                {lastFeeding.amount}ml/L)
-              </span>
-            ) : (
-              <span>{t("plantCard.noFeedingRecords")}</span>
-            )}
-          </div>
-          <div className="flex items-center">
-            <Scissors className="h-3 w-3 mr-1" />
-            {lastTraining ? (
-              <span>
-                {t("plantCard.lastTraining")}:{" "}
-                {t(`training.${lastTraining.method}`)}
-              </span>
-            ) : (
-              <span>{t("plantCard.noTrainingRecords")}</span>
-            )}
-          </div>
-        </div>
-      </CardFooter>
+      {!compact && (
+        <>
+          <CardContent className="pb-2">
+            <div className="flex items-center text-sm text-muted-foreground">
+              <Badge variant="outline" className="mr-2">
+                {plant.growType === "indoor"
+                  ? t("newPlant.indoor")
+                  : t("newPlant.outdoor")}
+              </Badge>
+              {plant.growType === "indoor" && plant.lightSchedule && (
+                <Badge variant="outline">{plant.lightSchedule}</Badge>
+              )}
+            </div>
+          </CardContent>
+          <CardFooter className="pt-0 text-xs text-muted-foreground">
+            <div className="space-y-1">
+              <div className="flex items-center">
+                <Calendar className="h-3 w-3 mr-1" />
+                {plant.plantingDate &&
+                  formatDateWithLocale(plant.plantingDate, "PPP", language)}
+              </div>
+              <div className="flex items-center">
+                <Droplet className="h-3 w-3 mr-1" />
+                {lastWatering ? (
+                  <span>
+                    {t("plantCard.lastWatering")}: {lastWatering.amount}ml (
+                    {t(`watering.${lastWatering.method}`)})
+                  </span>
+                ) : (
+                  <span>{t("plantCard.noWateringRecords")}</span>
+                )}
+              </div>
+              <div className="flex items-center">
+                <Zap className="h-3 w-3 mr-1" />
+                {lastFeeding ? (
+                  <span>
+                    {t("plantCard.lastFeeding")}: {lastFeeding.npk} (
+                    {lastFeeding.amount}ml/L)
+                  </span>
+                ) : (
+                  <span>{t("plantCard.noFeedingRecords")}</span>
+                )}
+              </div>
+              <div className="flex items-center">
+                <Scissors className="h-3 w-3 mr-1" />
+                {lastTraining ? (
+                  <span>
+                    {t("plantCard.lastTraining")}:{" "}
+                    {t(`training.${lastTraining.method}`)}
+                  </span>
+                ) : (
+                  <span>{t("plantCard.noTrainingRecords")}</span>
+                )}
+              </div>
+            </div>
+          </CardFooter>
+        </>
+      )}
     </Card>
   );
 }

--- a/components/providers/language-provider.tsx
+++ b/components/providers/language-provider.tsx
@@ -702,6 +702,12 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
         "search.noResults": "No se encontraron resultados",
         "search.searching": "Buscando...",
 
+        // Nutrients
+        "nutrients.title": "Nutrientes",
+        "nutrients.description": "Mezclas guardadas (NPK y notas).",
+        "nutrients.empty": "Sin mezclas",
+        "nutrients.emptyDesc": "Agrega tu primera mezcla para empezar",
+
         // Plant Card
         "plantCard.lastWatering": "Último riego",
         "plantCard.noWateringRecords": "No hay registros de riego",
@@ -1432,6 +1438,12 @@ export function LanguageProvider({ children }: LanguageProviderProps) {
         "search.placeholder": "Search plants, logs...",
         "search.noResults": "No results found",
         "search.searching": "Searching...",
+
+        // Nutrients
+        "nutrients.title": "Nutrients",
+        "nutrients.description": "Saved mixes (NPK and notes).",
+        "nutrients.empty": "No mixes",
+        "nutrients.emptyDesc": "Add your first mix to get started",
 
         // Plant Card
         "plantCard.lastWatering": "Last watering",

--- a/firestore.rules
+++ b/firestore.rules
@@ -35,6 +35,11 @@ service cloud.firestore {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
 
+      // Nutrient mixes
+      match /nutrientMixes/{mixId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
       // Stash
       match /stash/{itemId} {
         allow read, write: if request.auth != null && request.auth.uid == userId;

--- a/lib/firebase-config.ts
+++ b/lib/firebase-config.ts
@@ -8,6 +8,7 @@ export const COLLECTIONS = {
   LOGS: "logs",
   ENVIRONMENT: "environment",
   REMINDERS: "reminders",
+  NUTRIENT_MIXES: "nutrientMixes",
 } as const;
 
 // Storage paths
@@ -56,6 +57,17 @@ export const buildReminderPath = (
   reminderId: string
 ): string => {
   return `${COLLECTIONS.USERS}/${userId}/${COLLECTIONS.REMINDERS}/${reminderId}`;
+};
+
+export const buildNutrientMixesPath = (userId: string): string => {
+  return `${COLLECTIONS.USERS}/${userId}/${COLLECTIONS.NUTRIENT_MIXES}`;
+};
+
+export const buildNutrientMixPath = (
+  userId: string,
+  mixId: string
+): string => {
+  return `${COLLECTIONS.USERS}/${userId}/${COLLECTIONS.NUTRIENT_MIXES}/${mixId}`;
 };
 
 // Storage path builders

--- a/lib/routes.ts
+++ b/lib/routes.ts
@@ -14,6 +14,7 @@ export const ROUTE_SETTINGS = "/settings" as const;
 export const ROUTE_JOURNAL = "/journal" as const;
 export const ROUTE_REMINDERS = "/reminders" as const;
 export const ROUTE_STASH = "/stash" as const;
+export const ROUTE_NUTRIENTS = "/nutrients" as const;
 export const ROUTE_PRIVACY = "/privacy" as const;
 export const ROUTE_TERMS = "/terms" as const;
 export const ROUTE_ADMIN = "/admin" as const;
@@ -34,6 +35,7 @@ export type AppPath =
   | typeof ROUTE_JOURNAL
   | typeof ROUTE_REMINDERS
   | typeof ROUTE_STASH
+  | typeof ROUTE_NUTRIENTS
   | typeof ROUTE_PRIVACY
   | typeof ROUTE_TERMS
   | typeof ROUTE_ADMIN


### PR DESCRIPTION
- Implemented Firestore rules for managing nutrient mixes, allowing users to read and write their own mixes.
- Updated the dashboard to include a widget displaying recent logs and nutrient mixes count.
- Enhanced the layout with new navigation links for nutrient mixes and improved mobile navigation.
- Added environment data visualization in the plant detail view.
- Refactored various components for better organization and user experience, including the addition of a JournalEntries component for recent logs.