### PR TITLE
fix: invalidate plant caches on mobile edits

### DIFF
--- a/components/mobile/mobile-plant-page.tsx
+++ b/components/mobile/mobile-plant-page.tsx
@@ -50,6 +50,10 @@ import { InlineEdit } from "@/components/common/inline-edit";
 import { updateDoc, doc } from "firebase/firestore";
 import { plantDoc } from "@/lib/paths";
 import { ROUTE_PLANTS } from "@/lib/routes";
+import {
+  invalidatePlantDetails,
+  invalidatePlantsCache,
+} from "@/lib/suspense-cache";
 
 interface MobilePlantPageProps {
   plant: Plant;
@@ -301,6 +305,8 @@ export function MobilePlantPage({
                       await updateDoc(plantDoc(userId, plant.id), {
                         name: newName,
                       });
+                      invalidatePlantDetails(userId, plant.id);
+                      invalidatePlantsCache(userId);
                       onUpdate?.({ name: newName });
                     }}
                     placeholder={t("newPlant.namePlaceholder", {
@@ -463,6 +469,8 @@ export function MobilePlantPage({
                   await updateDoc(plantDoc(userId, plant.id), {
                     seedType: value,
                   });
+                  invalidatePlantDetails(userId, plant.id);
+                  invalidatePlantsCache(userId);
                   onUpdate?.({ seedType: value });
                 }}
               >
@@ -495,6 +503,8 @@ export function MobilePlantPage({
                   await updateDoc(plantDoc(userId, plant.id), {
                     growType: value,
                   });
+                  invalidatePlantDetails(userId, plant.id);
+                  invalidatePlantsCache(userId);
                   onUpdate?.({ growType: value });
                 }}
               >
@@ -527,6 +537,8 @@ export function MobilePlantPage({
                   await updateDoc(plantDoc(userId, plant.id), {
                     seedBank: newBank,
                   });
+                  invalidatePlantDetails(userId, plant.id);
+                  invalidatePlantsCache(userId);
                   onUpdate?.({ seedBank: newBank });
                 }}
                 placeholder={t("newPlant.seedBankPlaceholder", {


### PR DESCRIPTION
## Summary
- import the suspense cache invalidators into the mobile plant detail page
- clear the plant list and detail caches after saving inline edits for name, seed bank, seed type, and grow type

## Testing
- npm run build *(fails: unable to fetch Inter font from Google Fonts in offline CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d168a512b08325987ec9c0c9122d6c